### PR TITLE
Bugfix update_readme_history(): Use `__version__` from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,18 +107,30 @@ To make a new release, do this:
 * commit the changes
 * Create release
 
-Use this by git hooks, e.g.:
+It's recommended to use git hookd (via [pre-commit](https://pre-commit.com/)) to update the README.
+For this, add in your `pyproject.toml`:
+
+```toml
+[tool.cli_base]
+version_module_name = "<your_package>" # Must provide the `__version__` attribute
+```
+
+Copy&paste [.pre-commit-config.yaml](https://github.com/jedie/cli-base-utilities/blob/main/.pre-commit-config.yaml) into your project.
+
+Add `pre-commit` to your requirements and install the git hooks by:
 
 ```bash
 .venv/bin/pre-commit install
 .venv/bin/pre-commit autoupdate
 ```
 
+
 # history
 
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
-* [v0.7.0rc2](https://github.com/jedie/cli-base-utilities/compare/v0.6.0...v0.7.0rc2)
+* [v0.7.0rc3](https://github.com/jedie/cli-base-utilities/compare/v0.6.0...v0.7.0rc3)
+  * 2023-12-16 - Bugfix update_readme_history(): Use `__version__` from module
   * 2023-12-16 - NEW: "update-readme-history" git hook using "pre-commit"
   * 2023-12-16 - fix tests
   * 2023-12-16 - Bugfix type hints

--- a/cli_base/__init__.py
+++ b/cli_base/__init__.py
@@ -3,5 +3,7 @@
     Helpers to bild a CLI program
 """
 
-__version__ = '0.7.0rc2'
+# See https://packaging.python.org/en/latest/specifications/version-specifiers/
+__version__ = '0.7.0rc3'
+
 __author__ = 'Jens Diemer <github@jensdiemer.de>'

--- a/cli_base/cli_tools/tests/test_git_history.py
+++ b/cli_base/cli_tools/tests/test_git_history.py
@@ -1,6 +1,5 @@
 import inspect
 import os
-from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
 from bx_py_utils.test_utils.redirect import RedirectOut
@@ -51,15 +50,15 @@ class GitHistoryTestCase(BaseTestCase):
 
             with self.assertRaises(LookupError) as cm:
                 update_readme_history()
-            self.assertIn('No "project.name" in ', str(cm.exception))
+            self.assertIn('No "tool.cli_base.version_module_name" in ', str(cm.exception))
 
-            pyproject_toml_path.write_text('[project]\nname = "not_existing_project_name"\n')
+            pyproject_toml_path.write_text('[tool.cli_base]\nversion_module_name = "not_existing_module_name"\n')
 
-            with self.assertRaises(PackageNotFoundError) as cm:
+            with self.assertRaises(ModuleNotFoundError) as cm:
                 update_readme_history()
-            self.assertIn('not_existing_project_name', str(cm.exception))
+            self.assertIn('not_existing_module_name', str(cm.exception))
 
-            pyproject_toml_path.write_text('[project]\nname = "cli-base-utilities"\n')
+            pyproject_toml_path.write_text('[tool.cli_base]\nversion_module_name = "cli_base"\n')
 
             with self.assertRaises(NoGitRepoError) as cm:
                 update_readme_history()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ include = ["cli_base*"]
 version = {attr = "cli_base.__version__"}
 
 
+[tool.cli_base]
+version_module_name = "cli_base" # Used in cli_base.cli_tools.git_history.update_readme_history()
+
+
 [tool.darker]
 src = ['.']
 revision = "origin/main..."


### PR DESCRIPTION
Don't use `metadata.version(project_name)` because this is the installed version, but we need the current version number from `__version__`.

Because the git pre commit hook will switch the version in README back to `**dev**`, but this should only be used after a release.