### PR TITLE
Bugfix #50 toml2dataclass(): AttributeError: 'bool' object has no attribute 'unwrap'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ It's easier to temporarily uninstall the hooks, create the release and install t
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
 * [**dev**](https://github.com/jedie/cli-base-utilities/compare/v0.10.1...main)
+  * 2024-08-04 - Bugfix #50 toml2dataclass(): AttributeError: 'bool' object has no attribute 'unwrap'.
   * 2024-08-02 - Fix doc link in README.md
 * [v0.10.1](https://github.com/jedie/cli-base-utilities/compare/v0.10.0...v0.10.1)
   * 2024-08-02 - Increase default timout from 5 to 15 minutes

--- a/cli_base/toml_settings/deserialize.py
+++ b/cli_base/toml_settings/deserialize.py
@@ -67,6 +67,16 @@ def toml2dataclass(*, document: TOMLDocument | Table, instance, _changed=False) 
                 _changed = True
             else:
                 setattr(instance, field_name, Path(value))
+        elif isinstance(field_value, bool):
+            if not isinstance(doc_value, bool):
+                logger.error(
+                    'Toml value %s=%r is not a boolean -> ignored and use default value: %r',
+                    field_name,
+                    doc_value,
+                    field_value,
+                )
+                setattr(instance, field_name, field_value)
+                _changed = True
         elif not isinstance(field_value, type(doc_value.unwrap())):
             logger.error(
                 'Toml value %s=%r is type %r but must be type %r -> ignored and use default value!',


### PR DESCRIPTION
Fix for https://github.com/jedie/cli-base-utilities/issues/50