### PR TITLE
Fix git history caused by github

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ It's easier to temporarily uninstall the hooks, create the release and install t
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
 * [v0.20.0rc1](https://github.com/jedie/cli-base-utilities/compare/v0.19.0...v0.20.0rc1)
-  * 2025-07-29 - Fix git history caused by github
+  * 2025-08-04 - Fix git history caused by github
 * [v0.19.0](https://github.com/jedie/cli-base-utilities/compare/v0.18.0...v0.19.0)
   * 2025-07-29 - Expand Git() around commit message
   * 2025-07-29 - Update requirements


### PR DESCRIPTION
GitHub may add suffixes like "(#123)" to the commit message. This cause different Git histories: Before the merge and after a PR merge :(

Remove the suffix, to get always the same history.